### PR TITLE
NI: fix context::get_context()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0](https://github.com/3xMike/tritonserver-rs/tags/0.2.0) - 2024-12-20
+## [0.2.1](https://github.com/3xMike/tritonserver-rs/tags/0.2.1) - 2024-12-24
+### Fixed:
+- Error on context::get_context()
+
+## [0.2.0](https://github.com/3xMike/tritonserver-rs/tags/0.2.0) - 2024-12-23
 ### Changed:
 - Triton C-API version to 1.33.
 - Minimal TritonInferenceServer container version to 24.07.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tritonserver-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [
     "Mikhail Mikhailov <mikhailov.mm@phystech.edu>",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triton_examples"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [features]
@@ -27,7 +27,7 @@ config-manager = { version = "0.2.0" }
 env_logger = { version = "0.9" }
 log = "0.4"
 tokio = { version = "1.32", features = ["full"] }
-tritonserver-rs = { version = "0.2.0", default-features = false }
+tritonserver-rs = { version = "0.2.1", default-features = false }
 
 ab_glyph = { version = "0.2.23", optional = true }
 csv = { version = "1.3", optional = true }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    ffi::{c_char, c_int},
-    ptr::null_mut,
-    sync::Arc,
-};
+use std::{collections::HashMap, ffi::c_int, sync::Arc};
 
 use cuda_driver_sys::{
     cuCtxCreate_v2, cuCtxDestroy_v2, cuCtxGetApiVersion, cuCtxPopCurrent_v2, cuCtxPushCurrent_v2,
@@ -125,11 +120,11 @@ impl CuDevice {
 
     /// Get name of the device.
     pub fn get_name(&self) -> Result<String, Error> {
-        let name = null_mut::<c_char>();
+        let mut name = vec![0; 256];
 
         cuda_call!(
-            cuDeviceGetName(name, 256, self.device,),
-            from_char_array(name)
+            cuDeviceGetName(name.as_mut_ptr() as *mut _, 256, self.device,),
+            from_char_array(name.as_mut_ptr())
         )
     }
 


### PR DESCRIPTION
After Release 0.2.0, context::get_context() started to throw an error.