### PR TITLE
Fix DataType size

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -97,9 +97,13 @@ impl DataType {
             .unwrap_or(CSTR_CONVERT_ERROR_PLUG)
     }
 
-    /// Get the size of a Triton datatype in bytes. Zero is returned for [DataType::Bytes] because it have variable size.
+    /// Get the size of a Triton datatype in bytes. For [DataType::Bytes] the size of one element is returned.
     pub fn size(self) -> u32 {
-        unsafe { sys::TRITONSERVER_DataTypeByteSize(self as u32) }
+        if self == Self::Bytes {
+            size_of::<Byte>() as u32
+        } else {
+            unsafe { sys::TRITONSERVER_DataTypeByteSize(self as u32) }
+        }
     }
 }
 


### PR DESCRIPTION
In the case when the `DataType::size` function returns 0 for the `DataType::Bytes` variant, other functions incorrectly interpret this result. For example, the `Buffer::alloc_with_data_type` method determines the size of the buffer for allocation in this way, and for `DataType::Bytes` a zero buffer will always be allocated. As a result, a null pointer error occurs somewhere.