### PR TITLE
Empty output model log into trace level

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -356,7 +356,9 @@ impl InferenceResponseWrapper {
             .to_string();
 
         let shape = if dim_count == 0 {
-            log::warn!("Model returned output '{name}' of shape []. Consider removing this output");
+            log::trace!(
+                "Model returned output '{name}' of shape []. Consider removing this output"
+            );
             Vec::new()
         } else {
             unsafe { from_raw_parts(shape, dim_count as usize) }.to_vec()


### PR DESCRIPTION
The warn log level creates a large number of unnecessary logs.
For example, in the case when the output model is optional, and we expect it to be empty